### PR TITLE
Various fixes

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.5
+current_version = 2.0.6
 commit = False
 message = service version: {current_version} → {new_version}
 tag = False

--- a/.osparc/jupyter-math/metadata.yml
+++ b/.osparc/jupyter-math/metadata.yml
@@ -9,7 +9,7 @@ description:
 
   "
 key: simcore/services/dynamic/jupyter-math
-version: 2.0.5
+version: 2.0.6
 integration-version: 2.0.0
 type: dynamic
 authors:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.0.6] - 2022-05-08
+- shell and kernel now use the same python interpreter
+- fixes issue crashing when trusting notebooks
+- fixes issue crashing when copying README.ipynb
+
 ## [2.0.5] - 2022-03-03
 - `~/work/workspace` is now the default working directory containing `~/work/workspace/README.ipynb`
 - voila preview now works as expected

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,7 @@ ENV JP_LSP_VIRTUAL_DIR="/home/${NB_USER}/.virtual_documents"
 # Copying boot scripts
 COPY --chown=$NB_UID:$NB_GID docker /docker
 
-ENV PYTHONPATH="/src:$PYTHONPATH"
+RUN echo 'export PATH="/home/${NB_USER}/.venv/bin:$PATH"' >> "/home/${NB_USER}/.bashrc"
 
 EXPOSE 8888
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SHELL = /bin/sh
 .DEFAULT_GOAL := help
 
 export DOCKER_IMAGE_NAME ?= jupyter-math
-export DOCKER_IMAGE_TAG ?= 2.0.5
+export DOCKER_IMAGE_TAG ?= 2.0.6
 
 
 define _bumpversion

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   jupyter-math:
-    image: simcore/services/dynamic/jupyter-math:2.0.5
+    image: simcore/services/dynamic/jupyter-math:2.0.6
     ports:
       - "8888:8888"
     environment:

--- a/docker/boot_notebook.bash
+++ b/docker/boot_notebook.bash
@@ -10,7 +10,7 @@ echo "$INFO" "  Workdir :$(pwd)"
 
 # Trust all notebooks in the notebooks folder
 echo "$INFO" "trust all notebooks in path..."
-find "${NOTEBOOK_BASE_DIR}" -name '*.ipynb' -type f | xargs -I % /bin/bash -c 'jupyter trust % || true'
+find "${NOTEBOOK_BASE_DIR}" -name '*.ipynb' -type f | xargs -I % /bin/bash -c 'jupyter trust "%" || true' || true
 
 # Configure
 # Prevents notebook to open in separate tab

--- a/docker/entrypoint.bash
+++ b/docker/entrypoint.bash
@@ -66,7 +66,7 @@ else
     chown --recursive "$NB_USER" "${DY_SIDECAR_PATH_OUTPUTS}"
 fi
 
-mv "${NOTEBOOK_BASE_DIR}/README.ipynb" "${NOTEBOOK_BASE_DIR}/workspace/README.ipynb"
+mv "${NOTEBOOK_BASE_DIR}/README.ipynb" "${NOTEBOOK_BASE_DIR}/workspace/README.ipynb" || true
 
 echo "Removing write permissions from users in placed where they are not allowed to write:"
 echo "- /home/${NB_USER}/work"


### PR DESCRIPTION
- shell and kernel now use the same python interpreter
- no longer crashes when signing notebooks
- no longer crashes when copying README.ipynb