### PR TITLE
Is749/adds issue templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+  
+# Maps code in repository with maintainers
+# Order is important. The last matching pattern has the most precedence.
+# SEE https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners#example-of-a-codeowners-file
+
+
+# files and folders recursively
+Dockerfile          @GitHK
+Makefile            @GitHK
+
+# NOTE: '/' denotes the root of the repository
+/.github/            @pcrespov @GitHK
+/.osparc/            @pcrespov @GitHK @elisabettai
+/kernels/            @elisabettai
+/docker/             @pcrespov @GitHK

--- a/.github/ISSUE_TEMPLATE/ask_question.md
+++ b/.github/ISSUE_TEMPLATE/ask_question.md
@@ -1,0 +1,17 @@
+---
+name: 💬 Question
+about: Ask a question
+labels: question
+assignees: elisabettai, newton1985, app-team
+---
+
+## What version of this service are you using?
+
+<!--
+Check in osparc UI: 
+- Search for 'math' under SERVICES
+- Open the info dialog 
+- Copy& paste here the service KEY and VERSION. e.g. simcore/services/dynamic/jupyter-math 2.0.8
+-->
+
+## How can we help you?

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,44 @@
+---
+name: 🐛 Bug
+about: File a bug/issue
+labels: bug
+assignees: GitHK
+---
+
+## What version of this service are you using?
+
+<!--
+Check in osparc UI: 
+- Search for 'math' under SERVICES
+- Open the info dialog 
+- Copy& paste here the service KEY and VERSION. e.g. simcore/services/dynamic/jupyter-math 2.0.8
+-->
+
+## Long story short
+
+<!-- Please describe your problem and why the fix is important. -->
+
+## Expected behaviour
+
+<!-- What is the behaviour you expect? -->
+
+## Actual behaviour
+
+<!-- What's actually happening? -->
+
+## Steps to reproduce
+
+<!-- Please describe steps to reproduce the issue.
+     If you have a script that does that please include it here within
+     markdown code markup -->
+
+## Your environment
+
+<!-- Describe the environment you have that lead to your issue.
+     This includes aiohttp version, OS, proxy server and other bits that
+     are related to your case.
+
+     IMPORTANT: aiohttp is both server framework and client library.
+     For getting rid of confusing please put 'server', 'client' or 'both'
+     word here.
+     -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,28 @@
+---
+name: ✨  Feature request
+about: Suggest an idea to implement
+labels: enhancement
+assignees: elisabettai
+---
+
+## User Story
+
+<!-- A clear and concise description of how the feature works and looks like from the user's perspective.
+
+Ex. I want to be able the stop the running pipeline by pressing a stop button. If the pipeline is stopped, I see a info-level message confirming it in the logger, if it fails the message should be displayed in red (error). Also, all the progress bars in the nodes must be set to 0. -->
+
+## Example
+
+<!-- Any file/screenshot/photomontage/video/website is provided for a better understanding of the request -->
+
+
+## Definition of Done
+<!--
+A clear and concise description of what the feature requires.
+
+1. Play button turns into stop button when pipeline is running
+2. Stop button turns into play button when pipeline is finished
+3. Stop button turns into play button when pipeline is successfully stopped
+4. Logger displays messages everytime the play/stop button is pressed
+5. Progress bars are set to 0 when stopping pipeline
+6. Stop button has a Python interface -->


### PR DESCRIPTION

Following up with https://github.com/ITISFoundation/osparc-issues/issues/749, i create
- issue templates for this repo. After this PR is merged, they will be available under https://github.com/ITISFoundation/jupyter-math/issues/new/choose
- code ownership (auto-assignment of PRs)