### PR TITLE
Update metadata.yml

### DIFF
--- a/.osparc/jupyter-math/metadata.yml
+++ b/.osparc/jupyter-math/metadata.yml
@@ -87,4 +87,3 @@ boot-options:
         description:
           To start as Voila save a notebook as "voila.ipynb" in the root
           folder
-min-visible-inputs: 2


### PR DESCRIPTION
Removing min-visible-inputs, it breaks the publisher pipeline, e.g. [here](https://git.speag.com/oSparc/docker-publisher-osparc-services/-/jobs/2960701). 

Probably it should be `min_visible_inputs`. Also, this update should go to a new service version.