### PR TITLE
Update Dockerfile to install libopenblas-base

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.9
+current_version = 2.0.10
 commit = False
 message = service version: {current_version} → {new_version}
 tag = False

--- a/.github/workflows/check-image.yml
+++ b/.github/workflows/check-image.yml
@@ -19,4 +19,4 @@ jobs:
       - name: Build all images if multiple
         uses: docker://itisfoundation/ci-service-integration-library:v1.0.3-dev-4
         with:
-          args: docker-compose build
+          args: docker compose build

--- a/.osparc/jupyter-math/metadata.yml
+++ b/.osparc/jupyter-math/metadata.yml
@@ -9,7 +9,7 @@ description:
 
   "
 key: simcore/services/dynamic/jupyter-math
-version: 2.0.9
+version: 2.0.10
 integration-version: 2.0.0
 type: dynamic
 authors:

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ USER root
 
 RUN apt-get update && \
   apt-get install -y --no-install-recommends \
+  libopenblas-base \
   gfortran \
   ffmpeg \
   make \

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SHELL = /bin/sh
 .DEFAULT_GOAL := help
 
 export DOCKER_IMAGE_NAME ?= jupyter-math
-export DOCKER_IMAGE_TAG ?= 2.0.9
+export DOCKER_IMAGE_TAG ?= 2.0.10
 
 
 # PYTHON ENVIRON ---------------------------------------------------------------------------------------
@@ -53,12 +53,12 @@ compose-spec: ## runs ooil to assemble the docker-compose.yml file
 		sh -c "cd /${DOCKER_IMAGE_NAME} && ooil compose"
 
 build: | compose-spec	## build docker image
-	docker-compose build
+	docker compose build
 
 # To test built service locally -------------------------------------------------------------------------
 .PHONY: run-local
 run-local:	## runs image with local configuration
-	docker-compose --file docker-compose-local.yml up
+	docker compose --file docker-compose-local.yml up
 
 .PHONY: publish-local
 publish-local: ## push to local throw away registry to test integration

--- a/README.md
+++ b/README.md
@@ -31,3 +31,7 @@ make publish-local
 
 ### Testing manually
 After a new service version has been published on the master deployment, it can be manually tested. For example a Template, called "Test Jupyter-math 2.0.9 ipywidgets" can be used for internal testing on the master deployment.
+
+
+### Changelog
+v2.0.10 (2023-12-11): add openBLAS for faster Octave solution 

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   jupyter-math:
-    image: simcore/services/dynamic/jupyter-math:2.0.9
+    image: simcore/services/dynamic/jupyter-math:2.0.10
     ports:
       - "8888:8888"
     environment:


### PR DESCRIPTION
Installing OpenBLAS allows Octave to use an optimized BLAS library. For example, this results in significant speedups (>10) when solving LSEs with the Octave kernel.