### PR TITLE
Suppress logs when Jupyter is no running

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.0
+current_version = 3.0.1
 commit = False
 message = service version: {current_version} → {new_version}
 tag = False

--- a/.osparc/jupyter-math/metadata.yml
+++ b/.osparc/jupyter-math/metadata.yml
@@ -9,7 +9,7 @@ description:
 
   "
 key: simcore/services/dynamic/jupyter-math
-version: 3.0.0
+version: 3.0.1
 integration-version: 2.0.0
 type: dynamic
 authors:

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,7 @@ ENV JP_LSP_VIRTUAL_DIR="/home/${NB_USER}/.virtual_documents"
 COPY --chown=$NB_UID:$NB_GID docker /docker
 
 # install service activity monitor
-ARG ACTIVITY_MONITOR_VERSION=v0.0.3
+ARG ACTIVITY_MONITOR_VERSION=v0.0.4
 
 # Detection thresholds for application
 ENV ACTIVITY_MONITOR_BUSY_THRESHOLD_CPU_PERCENT=0.5

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SHELL = /bin/sh
 .DEFAULT_GOAL := help
 
 export DOCKER_IMAGE_NAME ?= jupyter-math
-export DOCKER_IMAGE_TAG ?= 3.0.0
+export DOCKER_IMAGE_TAG ?= 3.0.1
 
 
 # PYTHON ENVIRON ---------------------------------------------------------------------------------------

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   jupyter-math:
-    image: simcore/services/dynamic/jupyter-math:3.0.0
+    image: simcore/services/dynamic/jupyter-math:3.0.1
     ports:
       - "8888:8888"
     environment:


### PR DESCRIPTION
- bumped version to 3.0.1
- removes an issue with the activity monitor that logs tracebacks visible to the user when the Jupyter notebook has not started yet.