### PR TITLE
Fixed issues with Activity Monitor

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.3
+current_version = 3.0.4
 commit = False
 message = service version: {current_version} → {new_version}
 tag = False

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,6 @@ Makefile            @GitHK
 
 # NOTE: '/' denotes the root of the repository
 /.github/            @pcrespov @GitHK
-/.osparc/            @pcrespov @GitHK @elisabettai
-/kernels/            @elisabettai
+/.osparc/            @pcrespov @GitHK
+/kernels/            @GitHK
 /docker/             @pcrespov @GitHK

--- a/.osparc/jupyter-math/metadata.yml
+++ b/.osparc/jupyter-math/metadata.yml
@@ -9,7 +9,7 @@ description:
 
   "
 key: simcore/services/dynamic/jupyter-math
-version: 3.0.3
+version: 3.0.4
 integration-version: 2.0.0
 type: dynamic
 authors:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [3.0.4] - 2025-03-12
+- fixed an issue that made activity monitor to trigger errors
+
 ## [3.0.3] - 2024-06-20
 - attempt at fixing issues with usability on Firefox and Safari
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,7 @@ ENV JP_LSP_VIRTUAL_DIR="/home/${NB_USER}/.virtual_documents"
 COPY --chown=$NB_UID:$NB_GID docker /docker
 
 # install service activity monitor
-ARG ACTIVITY_MONITOR_VERSION=v0.0.4
+ARG ACTIVITY_MONITOR_VERSION=v0.0.5
 
 # Detection thresholds for application
 ENV ACTIVITY_MONITOR_BUSY_THRESHOLD_CPU_PERCENT=0.5

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SHELL = /bin/sh
 .DEFAULT_GOAL := help
 
 export DOCKER_IMAGE_NAME ?= jupyter-math
-export DOCKER_IMAGE_TAG ?= 3.0.3
+export DOCKER_IMAGE_TAG ?= 3.0.4
 
 
 # PYTHON ENVIRON ---------------------------------------------------------------------------------------

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   jupyter-math:
-    image: simcore/services/dynamic/jupyter-math:3.0.3
+    image: simcore/services/dynamic/jupyter-math:3.0.4
     ports:
       - "8888:8888"
     environment:


### PR DESCRIPTION
The activity monitor script was crashing when it did not have access to a sibling process. This will no longer occur.

For details see https://github.com/ITISFoundation/service-activity-monitor